### PR TITLE
overlay-scrollbar depends on gsettings-desktop-schemas-ubuntu

### DIFF
--- a/overlay-scrollbar/PKGBUILD
+++ b/overlay-scrollbar/PKGBUILD
@@ -35,7 +35,7 @@ build() {
 
 package_liboverlay-scrollbar3() {
   pkgdesc="Scrollbar overlayed widget - GTK 3 library"
-  depends=('glib2-ubuntu' 'gtk3-ubuntu')
+  depends=('glib2-ubuntu' 'gtk3-ubuntu' 'gsettings-desktop-schemas-ubuntu')
   provides=('overlay-scrollbar')
   conflicts=('overlay-scrollbar')
 
@@ -48,7 +48,7 @@ package_liboverlay-scrollbar3() {
 
 package_liboverlay-scrollbar() {
   pkgdesc="Scrollbar overlayed widget - GTK 2 library"
-  depends=('gtk2-ubuntu')
+  depends=('gtk2-ubuntu' 'gsettings-desktop-schemas-ubuntu')
 
   cd "${srcdir}/${pkgbase}-${pkgver}/build-gtk2"
   MAKEFLAGS="-j1"

--- a/qt-ubuntu/PKGBUILD
+++ b/qt-ubuntu/PKGBUILD
@@ -101,6 +101,8 @@ build() {
         -e '/10_config_tests_fixes.diff/d'                                \
       `# Not needed for rolling release distros`                          \
         -e '/23_permit_plugins_built_with_future_qt.diff/d'               \
+      `# Disable overlay scrollbar (not tested)`                          \
+      `# -e '/kubuntu_93_disable_overlay_scrollbars.diff/d'`              \
       \
       "${srcdir}/debian/patches/series"
 


### PR DESCRIPTION
overlay-scrollbar now depends on gsettings-desktop-schemas-ubuntu to work

qt-ubuntu patch requires [kubuntu_93_disable_overlay_scrollbars.diff](http://bazaar.launchpad.net/~ubuntu-branches/ubuntu/precise/qt4-x11/precise/view/head:/debian/patches/kubuntu_93_disable_overlay_scrollbars.diff) to solve problems with applications qt (launchpad bug [805303](https://bugs.launchpad.net/ubuntu/+source/qt4-x11/+bug/805303) )
