### PR TITLE
Add simple script to assist building and installation

### DIFF
--- a/build-and-install.sh
+++ b/build-and-install.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
-packages=(gtk2-ubuntu gtk3-ubuntu libdbusmenu libindicator libindicate libindicate-qt appmenu-gtk libunity libunity-misc indicator-messages libunity-webapps bamf sni-qt ido gnome-settings-daemon-ubuntu gnome-session-ubuntu gnome-control-center-ubuntu gnome-control-center-unity credentials-preferences metacity-ubuntu indicator-applet indicator-application indicator-appmenu indicator-bluetooth indicator-datetime indicator-power indicator-printers indicator-session indicator-sound network-manager-applet-ubuntu overlay-scrollbar evemu frame fixesproto-ubuntu libxfixes-ubuntu xorg-server-ubuntu grail geis nux unity-asset-pool nautilus-ubuntu python-oauthlib unity-lens-applications unity-lens-files unity-lens-music unity-lens-photos unity-lens-video unity-scope-video-remote compiz-ubuntu unity)
+#Todo
+# * add workaround for qt-ubuntu
+# * add option to install without user input
+packages=($(./What_can_I_update\?.py -l | grep -v qt-ubuntu))
 for package in "${packages[@]}"; do
 	cd "${package}"
-	rm -rf src
-	makepkg -fi
+	makepkg -fisc
 	cd ..
 done


### PR DESCRIPTION
Note: it doesn't build qt-ubuntu because I was too lazy to include the workaround.
All you have to do is input "y" when it asks if you're sure to install the package.
I can put in an option to install without confirmation later.
