### PR TITLE
Fix typo in compiz-ubuntu and disable gtest if not installed

### DIFF
--- a/compiz-ubuntu/PKGBUILD
+++ b/compiz-ubuntu/PKGBUILD
@@ -31,7 +31,7 @@ makedepends=('boost' 'cmake' 'intltool' 'libwnck')
 groups=('unity')
 options=('emptydirs')
 conflicts=('compiz')
-provides=('compiz-core compiz')
+provides=('compiz-core' 'compiz')
 install=compiz-ubuntu.install
 source=("https://launchpad.net/ubuntu/+archive/primary/+files/compiz_${_actual_ver}${_extra_ver}.orig.tar.gz"
         "https://launchpad.net/ubuntu/+archive/primary/+files/compiz_${_actual_ver}${_extra_ver}-${_ubuntu_rel}.diff.gz"

--- a/unity/PKGBUILD
+++ b/unity/PKGBUILD
@@ -62,8 +62,10 @@ build() {
     patch -p1 -i "debian/patches/${i}"
   done
 
-  # Disable gtest: depends highly on Ubuntu's packaging of gtest
-  #patch -p1 -i "${srcdir}/0001_Remove_gtest.patch"
+  # Disable gtest if gtest-ubuntu is not installed
+  if ! pacman -Q gtest-ubuntu &>/dev/null; then
+    patch -p1 -i "${srcdir}/0001_Remove_gtest.patch"
+  fi
 
   # Cannot find gmodule
   #CXXFLAGS="${CXXFLAGS} $(pkg-config --cflags --libs gmodule-2.0)"


### PR DESCRIPTION
This fixes a typo I made in compiz-ubuntu's PKGBUILD, and patches unity with 0001_Remove_gtest.patch if gtest-ubuntu isn't installed. Even with --nocheck Unity wasn't building without gtest installed.
