### PR TITLE
[bamf] fix not building without checkdepends

### DIFF
--- a/bamf/PKGBUILD
+++ b/bamf/PKGBUILD
@@ -26,8 +26,12 @@ build() {
 
   gtkdocize
   autoreconf -vfi
-
-  ./configure --prefix=/usr --libexecdir=/usr/lib --disable-static --enable-gtk-doc --enable-headless-tests
+  
+  if ! pacman -Q xorg-server-xvfb &>/dev/null; then
+    ./configure --prefix=/usr --libexecdir=/usr/lib --disable-static --enable-gtk-doc
+  else
+    ./configure --prefix=/usr --libexecdir=/usr/lib --disable-static --enable-gtk-doc --enable-headless-tests
+  fi
   make ${MAKEFLAGS}
 }
 


### PR DESCRIPTION
current ./configure doesn't work without xorg-server-xfvb
