### PR TITLE
Update repo-make.conf

### DIFF
--- a/repo-make.conf
+++ b/repo-make.conf
@@ -16,8 +16,9 @@ libindicator
 libindicate
 libindicate-qt
 libappindicator
-appmenu-gtk
+unity-gtk-module
 vala0.18
+dee-ubuntu
 libunity
 libunity-misc
 indicator-messages
@@ -29,6 +30,7 @@ gsettings-desktop-schemas-ubuntu
 gnome-settings-daemon-ubuntu
 gnome-session-ubuntu
 gnome-screensaver-ubuntu
+network-manager-applet-ubuntu
 gnome-control-center-ubuntu
 gnome-control-center-unity
 credentials-preferences-ubuntu
@@ -43,8 +45,10 @@ indicator-power
 indicator-printers
 indicator-session
 indicator-sound
+sphinxbase
+pocketsphinx
+sphinx-voxforge-en
 hud
-network-manager-applet-ubuntu
 overlay-scrollbar
 evemu
 frame
@@ -59,6 +63,8 @@ unity-lens-files
 unity-lens-music
 unity-lens-photos
 unity-lens-video
+#unity-scopes  #Disabled because of an incompatible and ugly PKGBUILD construction
 compiz-ubuntu
+xpathselect
 unity
 


### PR DESCRIPTION
I also added a comment for unity-scopes. repo-make is unable to compile this. (Same applies to unity-webapps)

I think it's the wrong way to use python scripts to generate a PKGBUILD. What would upstream developers say to that?

What about a script which generates one PKGBUILD for every scope?
I already started to write one, but first I need your OK.
