### PR TITLE
[indicator-session] dont patch tests/Makefile.am when not using tests

### DIFF
--- a/indicator-session/PKGBUILD
+++ b/indicator-session/PKGBUILD
@@ -37,7 +37,9 @@ prepare() {
 
   patch -p0 -i "${srcdir}/0001_Lock_Screen_Live_CD_Detection.patch"
   patch -p1 -i "${srcdir}/0002_There_is_no_help.patch"
-  patch -p1 -i "${srcdir}/0003_Link_Against_pthread.patch"
+  if pacman -Q gtest-ubuntu &>/dev/null; then
+    patch -p1 -i "${srcdir}/0003_Link_Against_pthread.patch"
+  fi
   patch -p0 -i "${srcdir}/0004_Lock_Screen_Guest_Session_Detection.patch"
 
   msg "Merging translations from ${_translations}"


### PR DESCRIPTION
fixes:

```
bp@bplap:~unity/Unity-for-Arch (git)-[master] % ./autoupdate.sh -Unyc 
==> resetting patches...
==> pulling from git...
Already up-to-date.
==> applying patches...
patching file compiz-ubuntu/PKGBUILD
Hunk #1 succeeded at 104 (offset 16 lines).
Hunk #2 succeeded at 114 with fuzz 2 (offset 15 lines).
patching file indicator-session/PKGBUILD
Hunk #1 succeeded at 56 (offset 22 lines).
==> building »indicator-session«
==> Making package: indicator-session 12.10.5daily13.06.19-100 (Mon Jun 24 18:43:39 CEST 2013)
==> Checking runtime dependencies...
==> Checking buildtime dependencies...
==> Retrieving sources...
  -> Found indicator-session_12.10.5daily13.06.19.orig.tar.gz
  -> Found translations-20130419-indicator-session.tar.gz
  -> Found 0001_Lock_Screen_Live_CD_Detection.patch
  -> Found 0002_There_is_no_help.patch
  -> Found 0003_Link_Against_pthread.patch
  -> Found 0004_Lock_Screen_Guest_Session_Detection.patch
==> Validating source files with sha512sums...
    indicator-session_12.10.5daily13.06.19.orig.tar.gz ... Passed
    translations-20130419-indicator-session.tar.gz ... Passed
    0001_Lock_Screen_Live_CD_Detection.patch ... Passed
    0002_There_is_no_help.patch ... Passed
    0003_Link_Against_pthread.patch ... Passed
    0004_Lock_Screen_Guest_Session_Detection.patch ... Passed
==> Extracting sources...
  -> Extracting indicator-session_12.10.5daily13.06.19.orig.tar.gz with bsdtar
  -> Extracting translations-20130419-indicator-session.tar.gz with bsdtar
==> Starting prepare()...
patching file src/session-menu-mgr.c
Hunk #2 succeeded at 1252 (offset -38 lines).
patching file src/session-menu-mgr.c
Hunk #1 succeeded at 429 (offset 49 lines).
patching file tests/Makefile.am
Hunk #1 FAILED at 40.
1 out of 1 hunk FAILED -- saving rejects to file tests/Makefile.am.rej
==> ERROR: A failure occurred in prepare().
    Aborting...
~/devel/misc.arch/unity/Unity-for-Arch

==> done.
skipped packages: 
ignored packages: 
failed  packages: ,indicator-session
```
