### PR TITLE
[lib32-sni-qt] Use 32-bit qconfig.h

### DIFF
--- a/lib32-sni-qt/PKGBUILD
+++ b/lib32-sni-qt/PKGBUILD
@@ -5,7 +5,7 @@
 
 pkgname=lib32-sni-qt
 pkgver=0.2.6
-pkgrel=2
+pkgrel=3
 pkgdesc="A Qt plugin which turns all QSystemTrayIcon into StatusNotifierItems (appindicators) (32-bit)"
 arch=(x86_64)
 url="https://launchpad.net/sni-qt"
@@ -13,8 +13,15 @@ license=(GPL)
 groups=(unity)
 depends=(sni-qt lib32-libdbusmenu-qt lib32-qt4-ubuntu)
 makedepends=(cmake gcc-multilib)
-source=("http://launchpad.net/sni-qt/trunk/${pkgver}/+download/sni-qt-${pkgver}.tar.bz2")
-sha512sums=('aa4cffeb3a5a70d65bd5ff42dcdd1c8efd107ade32a104b9a91696aecfb39a7a15d151f7491030ac0d7df796f2c7e4e6c3c0b7e32ee07a7cdc949da757147621')
+source=("http://launchpad.net/sni-qt/trunk/${pkgver}/+download/sni-qt-${pkgver}.tar.bz2"
+        "qconfig.h")
+sha512sums=('aa4cffeb3a5a70d65bd5ff42dcdd1c8efd107ade32a104b9a91696aecfb39a7a15d151f7491030ac0d7df796f2c7e4e6c3c0b7e32ee07a7cdc949da757147621'
+            '193ab479bcf35ecc5d75e575a7551016e416003fd26ac88664a5c64e6dcbf5ce50685c5803e0edba8c3b188d63acd15b7965fca771f03e6c8d573a0354d51290')
+
+prepare() {
+  mkdir -p "${srcdir}/QtCore"
+  ln -sf "${srcdir}/qconfig.h" "${srcdir}/QtCore/"
+}
 
 build() {
   cd "sni-qt-${pkgver}"
@@ -22,6 +29,9 @@ build() {
   export CC="gcc -m32"
   export CXX="g++ -m32"
   export PKG_CONFIG_PATH=/usr/lib32/pkgconfig
+
+  export CFLAGS="\"-I${srcdir}\" ${CFLAGS}"
+  export CXXFLAGS="\"-I${srcdir}\" ${CXXFLAGS}"
 
   cmake . \
     -DCMAKE_INSTALL_PREFIX=/usr \

--- a/lib32-sni-qt/qconfig.h
+++ b/lib32-sni-qt/qconfig.h
@@ -1,0 +1,172 @@
+/* Everything */
+
+/* Qt Edition */
+#ifndef QT_EDITION
+#  define QT_EDITION QT_EDITION_OPENSOURCE
+#endif
+
+/* Machine byte-order */
+#define Q_BIG_ENDIAN 4321
+#define Q_LITTLE_ENDIAN 1234
+#define QT_BUILD_KEY "i386 linux g++-4 full-config"
+#define QT_BUILD_KEY_COMPAT "i686 Linux g++-4 full-config"
+
+#ifdef QT_BOOTSTRAPPED
+#define Q_BYTE_ORDER Q_LITTLE_ENDIAN
+#else
+#define Q_BYTE_ORDER Q_LITTLE_ENDIAN
+#endif
+/* Machine Architecture */
+#ifndef QT_BOOTSTRAPPED
+# define QT_ARCH_I386
+#else
+# define QT_ARCH_I386
+#endif
+/* Compile time features */
+#define QT_LARGEFILE_SUPPORT 64
+#define QT_POINTER_SIZE 4
+
+#ifndef QT_BOOTSTRAPPED
+
+#if defined(QT_GRAPHICSSYSTEM_RASTER) && defined(QT_NO_GRAPHICSSYSTEM_RASTER)
+# undef QT_GRAPHICSSYSTEM_RASTER
+#elif !defined(QT_GRAPHICSSYSTEM_RASTER) && !defined(QT_NO_GRAPHICSSYSTEM_RASTER)
+# define QT_GRAPHICSSYSTEM_RASTER
+#endif
+
+#if defined(QT_LINKED_OPENSSL) && defined(QT_NO_LINKED_OPENSSL)
+# undef QT_LINKED_OPENSSL
+#elif !defined(QT_LINKED_OPENSSL) && !defined(QT_NO_LINKED_OPENSSL)
+# define QT_LINKED_OPENSSL
+#endif
+
+#if defined(QT_NO_EGL) && defined(QT_EGL)
+# undef QT_NO_EGL
+#elif !defined(QT_NO_EGL) && !defined(QT_EGL)
+# define QT_NO_EGL
+#endif
+
+#if defined(QT_NO_GSTREAMER) && defined(QT_GSTREAMER)
+# undef QT_NO_GSTREAMER
+#elif !defined(QT_NO_GSTREAMER) && !defined(QT_GSTREAMER)
+# define QT_NO_GSTREAMER
+#endif
+
+#if defined(QT_NO_ICD) && defined(QT_ICD)
+# undef QT_NO_ICD
+#elif !defined(QT_NO_ICD) && !defined(QT_ICD)
+# define QT_NO_ICD
+#endif
+
+#if defined(QT_NO_IMAGEFORMAT_JPEG) && defined(QT_IMAGEFORMAT_JPEG)
+# undef QT_NO_IMAGEFORMAT_JPEG
+#elif !defined(QT_NO_IMAGEFORMAT_JPEG) && !defined(QT_IMAGEFORMAT_JPEG)
+# define QT_NO_IMAGEFORMAT_JPEG
+#endif
+
+#if defined(QT_NO_IMAGEFORMAT_MNG) && defined(QT_IMAGEFORMAT_MNG)
+# undef QT_NO_IMAGEFORMAT_MNG
+#elif !defined(QT_NO_IMAGEFORMAT_MNG) && !defined(QT_IMAGEFORMAT_MNG)
+# define QT_NO_IMAGEFORMAT_MNG
+#endif
+
+#if defined(QT_NO_IMAGEFORMAT_TIFF) && defined(QT_IMAGEFORMAT_TIFF)
+# undef QT_NO_IMAGEFORMAT_TIFF
+#elif !defined(QT_NO_IMAGEFORMAT_TIFF) && !defined(QT_IMAGEFORMAT_TIFF)
+# define QT_NO_IMAGEFORMAT_TIFF
+#endif
+
+#if defined(QT_NO_NAS) && defined(QT_NAS)
+# undef QT_NO_NAS
+#elif !defined(QT_NO_NAS) && !defined(QT_NAS)
+# define QT_NO_NAS
+#endif
+
+#if defined(QT_NO_OPENVG) && defined(QT_OPENVG)
+# undef QT_NO_OPENVG
+#elif !defined(QT_NO_OPENVG) && !defined(QT_OPENVG)
+# define QT_NO_OPENVG
+#endif
+
+#if defined(QT_NO_PHONON) && defined(QT_PHONON)
+# undef QT_NO_PHONON
+#elif !defined(QT_NO_PHONON) && !defined(QT_PHONON)
+# define QT_NO_PHONON
+#endif
+
+#if defined(QT_NO_PULSEAUDIO) && defined(QT_PULSEAUDIO)
+# undef QT_NO_PULSEAUDIO
+#elif !defined(QT_NO_PULSEAUDIO) && !defined(QT_PULSEAUDIO)
+# define QT_NO_PULSEAUDIO
+#endif
+
+#if defined(QT_NO_S60) && defined(QT_S60)
+# undef QT_NO_S60
+#elif !defined(QT_NO_S60) && !defined(QT_S60)
+# define QT_NO_S60
+#endif
+
+#if defined(QT_NO_STYLE_S60) && defined(QT_STYLE_S60)
+# undef QT_NO_STYLE_S60
+#elif !defined(QT_NO_STYLE_S60) && !defined(QT_STYLE_S60)
+# define QT_NO_STYLE_S60
+#endif
+
+#if defined(QT_NO_SXE) && defined(QT_SXE)
+# undef QT_NO_SXE
+#elif !defined(QT_NO_SXE) && !defined(QT_SXE)
+# define QT_NO_SXE
+#endif
+
+#if defined(QT_NO_WEBKIT) && defined(QT_WEBKIT)
+# undef QT_NO_WEBKIT
+#elif !defined(QT_NO_WEBKIT) && !defined(QT_WEBKIT)
+# define QT_NO_WEBKIT
+#endif
+
+#if defined(QT_NO_ZLIB) && defined(QT_ZLIB)
+# undef QT_NO_ZLIB
+#elif !defined(QT_NO_ZLIB) && !defined(QT_ZLIB)
+# define QT_NO_ZLIB
+#endif
+
+#if defined(QT_RUNTIME_XCURSOR) && defined(QT_NO_RUNTIME_XCURSOR)
+# undef QT_RUNTIME_XCURSOR
+#elif !defined(QT_RUNTIME_XCURSOR) && !defined(QT_NO_RUNTIME_XCURSOR)
+# define QT_RUNTIME_XCURSOR
+#endif
+
+#if defined(QT_RUNTIME_XFIXES) && defined(QT_NO_RUNTIME_XFIXES)
+# undef QT_RUNTIME_XFIXES
+#elif !defined(QT_RUNTIME_XFIXES) && !defined(QT_NO_RUNTIME_XFIXES)
+# define QT_RUNTIME_XFIXES
+#endif
+
+#if defined(QT_RUNTIME_XINERAMA) && defined(QT_NO_RUNTIME_XINERAMA)
+# undef QT_RUNTIME_XINERAMA
+#elif !defined(QT_RUNTIME_XINERAMA) && !defined(QT_NO_RUNTIME_XINERAMA)
+# define QT_RUNTIME_XINERAMA
+#endif
+
+#if defined(QT_RUNTIME_XINPUT) && defined(QT_NO_RUNTIME_XINPUT)
+# undef QT_RUNTIME_XINPUT
+#elif !defined(QT_RUNTIME_XINPUT) && !defined(QT_NO_RUNTIME_XINPUT)
+# define QT_RUNTIME_XINPUT
+#endif
+
+#if defined(QT_RUNTIME_XRANDR) && defined(QT_NO_RUNTIME_XRANDR)
+# undef QT_RUNTIME_XRANDR
+#elif !defined(QT_RUNTIME_XRANDR) && !defined(QT_NO_RUNTIME_XRANDR)
+# define QT_RUNTIME_XRANDR
+#endif
+
+#if defined(QT_USE_MATH_H_FLOATS) && defined(QT_NO_USE_MATH_H_FLOATS)
+# undef QT_USE_MATH_H_FLOATS
+#elif !defined(QT_USE_MATH_H_FLOATS) && !defined(QT_NO_USE_MATH_H_FLOATS)
+# define QT_USE_MATH_H_FLOATS
+#endif
+
+#endif // QT_BOOTSTRAPPED
+
+#define QT_VISIBILITY_AVAILABLE
+


### PR DESCRIPTION
The plugin produced by the build contains a x86-64 build key as it is
built against the "qconfig.h" file produced by the x86-64 build for the
host system. In turn, the 32-bit build of Qt refuses to load the plugin
as the build key does not match.

Fix this by providing a custom "qconfig.h" file during the build and
prepending its location in the preprocessor's include search path. This
is the same approach chosen in the "lib32-qtcurve" package which is part
of the multilib repository.