### PR TITLE
[What-can-I-update.py] print error-message to stderr

### DIFF
--- a/What_can_I_update?.py
+++ b/What_can_I_update?.py
@@ -11,7 +11,7 @@ import textwrap
 try:
     import pyalpm
 except:
-    print('Please install the pyalpm package')
+    sys.stderr.write('Please install the pyalpm package!')
     sys.exit(1)
 
 from pycman import config


### PR DESCRIPTION
Behaviour before:

If `build-and-install.sh` calls `What_can_I_update?.py -l`, it will save the "error"-message in the $packages-array and It won't get printed out.

Behavour after:

The error-message `Please install the pyalpm package!` will now get shown, because it is processed on STDERR and `build-and-install.sh` exits because the array is empty and the for-loop not executed.

Sorry for possibly not merging it into the right branch.