### PR TITLE
[lightdm-ubuntu] Proposal: Add 'lightdm-gtk-greeter' in comflicts array

### DIFF
--- a/lightdm-ubuntu/PKGBUILD
+++ b/lightdm-ubuntu/PKGBUILD
@@ -11,7 +11,7 @@
 pkgname=lightdm-ubuntu
 _ubuntu_rel=0ubuntu1
 pkgver=1.13.2
-pkgrel=1
+pkgrel=2
 pkgdesc="A lightweight display manager"
 arch=(i686 x86_64)
 url="https://launchpad.net/lightdm"
@@ -29,7 +29,7 @@ optdepends=('accountsservice: DBus interface for querying user information'
             'qt4: To use the qt4 version of liblightdm-qt'
             'qt5-base: To use the qt5 version of liblightdm-qt')
 provides=("lightdm=${pkgver}" "liblightdm-qt4=${pkgver}")
-conflicts=(lightdm liblightdm-qt4)
+conflicts=(lightdm lightdm-gtk-greeter liblightdm-qt4)
 options=(emptydirs)
 backup=(etc/lightdm/keys.conf
         etc/lightdm/lightdm.conf


### PR DESCRIPTION
Hello @chenxiaolong ,

Appreciate your great job. :rose: However, I have a small proposal for the package 'lightdm-ubuntu'. That is: add 'lightdm-gtk-greeter' in comflicts array of the PKGBUILD file.

Since package 'lightdm-ubuntu' includes file '/etc/lightdm/lightdm-gtk-greeter.conf' and so does package 'lightdm-gtk-greeter' in the [community] repo, pacman would fail to install the other one when either one is installed.

See https://www.archlinux.org/packages/community/x86_64/lightdm-gtk-greeter/files/ for details.

Do you agree with me? :sunglasses: Hope for your reply!

Yours sincerely! :bow: 