### PR TITLE
[indicator-session] Update to version 12.10.5+15.04.20150327

### DIFF
--- a/indicator-session/PKGBUILD
+++ b/indicator-session/PKGBUILD
@@ -8,9 +8,9 @@
 
 pkgname=indicator-session
 _actual_ver=12.10.5
-_extra_ver=+15.04.20150228
+_extra_ver=+15.04.20150327
 pkgver=${_actual_ver}${_extra_ver/\+/.}
-pkgrel=2
+pkgrel=1
 epoch=1
 pkgdesc="Indicator showing session management, status and user switching"
 arch=(i686 x86_64)
@@ -24,7 +24,7 @@ install=${pkgname}.install
 source=("https://launchpad.net/ubuntu/+archive/primary/+files/indicator-session_${_actual_ver}${_extra_ver}.orig.tar.gz"
         indicator-session.service
         0001-There-is-no-help.patch)
-sha512sums=('663d0bc0f07b14ce6dceaf43658fa115f3ae3f08ec4900bf32bb66459da859e9a7435c3d3a98fae58880274a0378c3c2abd6f44a45df2be1b408be31f09a1030'
+sha512sums=('2ea31612753cf625e12a0b3b26db0e4f9627b1bc948170911c84639d082ccdccb180c363d57150feb679859bcfa957aec1d185b67307dedf42eb37cf82219b4e'
             '540c76c0f68b028194bb1000dd61a0c24f2f16427e79d237b94b8c65fe5e3e16eb6ea645f0fd33d734113727e25b6eb7452cb72f72399c9e8d370f74abba7511'
             'eceaaff3c90cd04bd2f1fd11f987965fdbfdfabf29aff6a258fb426ac0c2c33b2543b92d9e15cb3f7742619817f70c22867aed29978f9ab6dc17490dc4d1654b')
 


### PR DESCRIPTION
Hello @chenxiaolong ,

Since Ubuntu 15.04 decides to provide `indicator-session` version `12.10.5+15.04.20150327-0ubuntu1` in https://launchpad.net/ubuntu/vivid/+source/indicator-session , maybe we'd better follow the upstream. However, using `indicator-session_12.10.5+15.04.20150327.orig.tar.gz` works great (at least on my computer). You can read my build log here:

* https://build.opensuse.org/package/live_build_log/home:firef0x/indicator-session/Arch_Extra/x86_64
* https://build.opensuse.org/package/live_build_log/home:firef0x/indicator-session/Arch_Extra/i586

What's more, the version of [package indicator-session in AUR](https://aur.archlinux.org/packages/indicator-session/) is too old(3 years ago), and I want to sync with this repo. Is it suitable? :confused: 

Yours sincerely! :bow: 